### PR TITLE
Mnt remove pylab

### DIFF
--- a/groopm/bin.py
+++ b/groopm/bin.py
@@ -37,7 +37,7 @@
 #    along with this program. If not, see <http://www.gnu.org/licenses/>.     #
 #                                                                             #
 ###############################################################################
-
+from __future__ import print_function
 __author__ = "Michael Imelfort"
 __copyright__ = "Copyright 2012/2013"
 __credits__ = ["Michael Imelfort"]
@@ -155,7 +155,7 @@ class Bin:
         """Combine the contigs of another bin with this one"""
         # consume all the other bins rowIndices
         if(verbose):
-            print "    BIN:",deadBin.id,"will be consumed by BIN:",self.id
+            print("    BIN:",deadBin.id,"will be consumed by BIN:",self.id)
         self.rowIndices = np.concatenate([self.rowIndices, deadBin.rowIndices])
         self.binSize  = self.rowIndices.shape[0]
 
@@ -167,7 +167,7 @@ class Bin:
 
         This is the norm of the vector containing z distances for both profiles
         """
-        #print self.covStdevs, self.binSize
+        #print(self.covStdevs, self.binSize)
         covZ = np.abs(np.mean(np.abs(transformedCP - self.covMedians)/self.covStdevs))
         merZ = np.abs(kmerVal - self.kValMeanNormPC1)/self.kValStdevNormPC1
         return (covZ,merZ)
@@ -211,7 +211,7 @@ class Bin:
 
         The distribution is largely normal, except at the boundaries.
         """
-        #print "MBD", self.id, self.binSize
+        #print("MBD", self.id, self.binSize)
         self.binSize = self.rowIndices.shape[0]
         if(0 == np.size(self.rowIndices)):
             return
@@ -326,7 +326,7 @@ class Bin:
             try:
                 return ET.getMinVolEllipse(bin_points, retA=retA)
             except:
-                print bin_points
+                print(bin_points)
                 raise
         else: # minimum bounding ellipse of a point is 0
             if retA:
@@ -474,13 +474,13 @@ class Bin:
                 fig.set_size_inches(10,4)
                 plt.savefig(fileName,dpi=300)
             except:
-                print "Error saving image:", fileName, sys.exc_info()[0]
+                print("Error saving image:", fileName, sys.exc_info()[0])
                 raise
         else:
             try:
                 plt.show()
             except:
-                print "Error showing image:", sys.exc_info()[0]
+                print("Error showing image:", sys.exc_info()[0])
                 raise
         del fig
 
@@ -503,13 +503,13 @@ class Bin:
                 fig.set_size_inches(6,6)
                 plt.savefig(fileName+".png",dpi=300)
             except:
-                print "Error saving image:", fileName, sys.exc_info()[0]
+                print("Error saving image:", fileName, sys.exc_info()[0])
                 raise
         else:
             try:
                 plt.show()
             except:
-                print "Error showing image:", sys.exc_info()[0]
+                print("Error showing image:", sys.exc_info()[0])
                 raise
         plt.close(fig)
         del fig
@@ -664,7 +664,7 @@ class Bin:
                 ET.plotEllipse(center, radii, rotation, ax=ax, plotAxes=False, cageColor=centroid_color)
 
     def printBin(self, contigNames, covProfiles, contigGCs, contigLengths, isLikelyChimeric, outFormat="summary", separator="\t", stream=sys.stdout):
-        """print this bin info in csvformat"""
+        """print(this bin info in csvformat"""
         kvm_str = "%.4f" % self.kValMeanNormPC1
         kvs_str = "%.4f" % self.kValStdevNormPC1
         cvm_str = "%.4f" % self.cValMedian

--- a/groopm/bin.py
+++ b/groopm/bin.py
@@ -50,7 +50,6 @@ __email__ = "mike@mikeimelfort.com"
 import sys
 
 import matplotlib.pyplot as plt
-from pylab import show
 
 import numpy as np
 from numpy import (around as np_around,
@@ -70,6 +69,7 @@ np.seterr(all='raise')
 ###############################################################################
 
 # matplotlib hates me
+
 
 def mungeCbar(cbar):
     '''Set dims of the colorbar by hacking the mainframe and coping with
@@ -484,7 +484,6 @@ class Bin:
                 raise
         del fig
 
-
     def plotBin(self, transformedCP, contigGCs, kmerNormPC1, contigLengths, colorMapGC, isLikelyChimeric, fileName="", ignoreContigLengths=False, ET=None):
         """Plot a single bin"""
         fig = plt.figure()
@@ -506,7 +505,7 @@ class Bin:
             except:
                 print "Error saving image:", fileName, sys.exc_info()[0]
                 raise
-        elif(show):
+        else:
             try:
                 plt.show()
             except:

--- a/groopm/binManager.py
+++ b/groopm/binManager.py
@@ -53,25 +53,19 @@ from operator import itemgetter
 
 
 import matplotlib.pyplot as plt
-from pylab import show
-from numpy import (abs as np_abs,
-                   append as np_append,
+
+from numpy import (append as np_append,
                    arange as np_arange,
                    arccos as np_arccos,
-                   argmax as np_argmax,
                    argsort as np_argsort,
-                   around as np_around,
                    array as np_array,
-                   bincount as np_bincount,
                    ceil as np_ceil,
                    concatenate as np_concatenate,
                    dot as np_dot,
-                   log10 as np_log10,
                    max as np_max,
                    mean as np_mean,
                    median as np_median,
                    min as np_min,
-                   ones as np_ones,
                    reshape as np_reshape,
                    seterr as np_seterr,
                    size as np_size,
@@ -79,11 +73,10 @@ from numpy import (abs as np_abs,
                    sqrt as np_sqrt,
                    std as np_std,
                    sum as np_sum,
-                   where as np_where,
                    zeros as np_zeros)
 
 from scipy.stats import f_oneway, distributions
-from scipy.cluster.vq import kmeans,vq
+from scipy.cluster.vq import kmeans, vq
 
 # GroopM imports
 from profileManager import ProfileManager
@@ -1507,7 +1500,7 @@ class BinManager:
             except:
                 print("Error saving image:", fileName, exc_info()[0])
                 raise
-        elif(show):
+        else:
             try:
                 plt.show()
             except:

--- a/groopm/binManager.py
+++ b/groopm/binManager.py
@@ -37,6 +37,7 @@
 #    along with this program. If not, see <http://www.gnu.org/licenses/>.     #
 #                                                                             #
 ###############################################################################
+from __future__ import print_function
 
 __author__ = "Michael Imelfort"
 __copyright__ = "Copyright 2012/2013"
@@ -182,15 +183,15 @@ class BinManager:
                 if self.PM.numStoits == 3:
                     self.PM.transformedCP = self.PM.covProfiles
                 else:
-                    print "Number of stoits != 3. You need to transform"
+                    print("Number of stoits != 3. You need to transform")
                     self.PM.transformCP(timer, silent=silent)
             if not silent:
-                print "    Making bin objects"
+                print("    Making bin objects")
             self.makeBins(self.getBinMembers())
             if not silent:
-                print "    Loaded %d bins from database" % len(self.bins)
+                print("    Loaded %d bins from database" % len(self.bins))
         if not silent:
-            print "    %s" % timer.getTimeStamp()
+            print("    %s" % timer.getTimeStamp())
             sys_stdout.flush()
 
     def getBinMembers(self):
@@ -224,8 +225,8 @@ class BinManager:
                     self.bins[bid] = Bin(np_array(binMembers[bid]), bid, self.PM.scaleFactor-1)
                     self.bins[bid].makeBinDist(self.PM.transformedCP, self.PM.averageCoverages, self.PM.kmerNormPC1, self.PM.kmerPCs, self.PM.contigGCs, self.PM.contigLengths)
         if len(invalid_bids) != 0:
-            print "MT bins!"
-            print invalid_bids
+            print("MT bins!")
+            print(invalid_bids)
             exit(-1)
 
     def saveBins(self, binAssignments={}, nuke=False):
@@ -339,23 +340,23 @@ class BinManager:
         bin2count = {}
         for row_index in bin.rowIndices:
             try:
-                #print row_index, len(self.PM.links[row_index]), self.PM.links[row_index], "===",
+                #print(row_index, len(self.PM.links[row_index]), self.PM.links[row_index], "===",)
                 for link in self.PM.links[row_index]:
-                    #print "{{{",link,"}}}",
+                    #print("{{{",link,"}}}",)
                     try:
                         link_bid = self.PM.binIds[link[0]]
-                        #print ";;", link_bid, bid ,
+                        #print(";;", link_bid, bid ,)
                         if link_bid != bid and link_bid != 0:
                             try:
                                 bin2count[link_bid] += 1.0
                             except KeyError:
                                 bin2count[link_bid] = 1.0
                     except KeyError:
-                        pass#print "****\n\n"
-                #print "[[[[\n\n"
+                        pass#print("****\n\n")
+                #print("[[[[\n\n")
             except KeyError:
                 pass
-        #print bin2count
+        #print(bin2count)
         return bin2count
 
     def getConnectedBins(self, rowIndex):
@@ -468,7 +469,7 @@ class BinManager:
         (bin_assignment_update, bids) = self.getSplitties(bid, n, mode)
 
         if(auto and saveBins):
-            print 'here!!!!'
+            print('here!!!!')
             # charge on through
             self.deleteBins([bids[0]], force=True)  # delete the combined bin
             # save new bins
@@ -538,10 +539,10 @@ class BinManager:
                 try:
                     parts = int(raw_input("Enter new number of parts:"))
                 except ValueError:
-                    print "You need to enter an integer value!"
+                    print("You need to enter an integer value!")
                     parts = 0
                 if(1 == parts):
-                    print "Don't be a silly sausage!"
+                    print("Don't be a silly sausage!")
                 elif(0 != parts):
                     not_got_parts = False
                     self.split(bid,
@@ -664,7 +665,7 @@ class BinManager:
         F_cutoff =  distributions.f.ppf(confidence, 2, len(dist1)+len(dist2)-2)
         F_value = f_oneway(dist1,dist2)[0]
         if tag != "":
-            print "%s [V: %f, C: %f]" % (tag, F_value, F_cutoff)
+            print("%s [V: %f, C: %f]" % (tag, F_value, F_cutoff))
         return F_value < F_cutoff
 
     def merge(self, bids, auto=False, manual=False, newBid=False, saveBins=False, verbose=False, printInstructions=True, use_elipses=True):
@@ -715,11 +716,11 @@ class BinManager:
                 self.deleteBins([tmp_bin.id], force=True)
                 user_option = self.promptOnMerge(bids=[parent_bin.id,dead_bin.id])
                 if(user_option == "N"):
-                    print "Merge skipped"
+                    print("Merge skipped")
                     ret_val = 1
                     continue_merge=False
                 elif(user_option == "Q"):
-                    print "All mergers skipped"
+                    print("All mergers skipped")
                     return 0
                 else:
                     ret_val = 2
@@ -799,7 +800,7 @@ class BinManager:
                         try:
                             del self.PM.binnedRowIndices[row_index]
                         except KeyError:
-                            print bid, row_index, "FUNG"
+                            print(bid, row_index, "FUNG")
                         self.PM.binIds[row_index] = 0
 
                         bin_assignment_update[row_index] = 0
@@ -836,7 +837,7 @@ class BinManager:
                    " to continue with the merging operation.\n"
                    " The image on the far right shows the bins after merging\n"
                    " Press any key to produce plots...")
-        print "****************************************************************"
+        print("****************************************************************")
 
     def printSplitInstructions(self):
         raw_input( "****************************************************************\n"
@@ -848,7 +849,7 @@ class BinManager:
                    " be split. Look carefully at each plot and then close the plot\n"
                    " to continue with the splitting operation.\n\n"
                    " Press any key to produce plots...")
-        print "****************************************************************"
+        print("****************************************************************")
 
     def getPlotterMergeIds(self):
         """Prompt the user for ids to be merged and check that it's all good"""
@@ -866,13 +867,13 @@ class BinManager:
                     i_bid = int(bid)
                     # check that it's in the bins list
                     if(i_bid not in self.bins):
-                        print "**Error: bin",bid,"not found"
+                        print("**Error: bin",bid,"not found")
                         input_not_ok = True
                         break
                     input_not_ok = False
                     ret_bids.append(i_bid)
                 except ValueError:
-                    print "**Error: invalid value:", bid
+                    print("**Error: invalid value:", bid)
                     input_not_ok = True
                     break
         return ret_bids
@@ -898,10 +899,10 @@ class BinManager:
                                    " y = yes, n = no, q = no and quit merging\n" \
                                    " Merge? ("+vrs+") : ")
             if(option.upper() in valid_responses):
-                print "****************************************************************"
+                print("****************************************************************")
                 return option.upper()
             else:
-                print "Error, unrecognised choice '"+option.upper()+"'"
+                print("Error, unrecognised choice '"+option.upper()+"'")
                 minimal = True
 
     def promptOnSplit(self, parts, mode, minimal=False):
@@ -923,13 +924,13 @@ class BinManager:
                                    " Split? ("+vrs+") : ")
             if(option.upper() in valid_responses):
                 if(option.upper() == 'K' and mode.upper() == 'KMER' or option.upper() == 'C' and mode.upper() == 'COV' or option.upper() == 'L' and mode.upper() == 'LEN'):
-                    print "Error, you are already using that profile to split!"
+                    print("Error, you are already using that profile to split!")
                     minimal=True
                 else:
-                    print "****************************************************************"
+                    print("****************************************************************")
                     return option.upper()
             else:
-                print "Error, unrecognised choice '"+option.upper()+"'"
+                print("Error, unrecognised choice '"+option.upper()+"'")
                 minimal = True
 
     def promptOnDelete(self, bids, minimal=False):
@@ -949,10 +950,10 @@ class BinManager:
                                    " y = yes, n = no\n"\
                                    " Delete? ("+vrs+") : ")
             if(option.upper() in valid_responses):
-                print "****************************************************************"
+                print("****************************************************************")
                 return option.upper()
             else:
-                print "Error, unrecognised choice '"+option.upper()+"'"
+                print("Error, unrecognised choice '"+option.upper()+"'")
                 minimal = True
 
 #------------------------------------------------------------------------------
@@ -1054,7 +1055,7 @@ class BinManager:
 
         return a list of potentially confounding kmer indices
         """
-        print "    Measuring kmer type variances"
+        print("    Measuring kmer type variances")
         means = np_array([])
         stdevs = np_array([])
         bids = np_array([])
@@ -1094,12 +1095,12 @@ class BinManager:
                 return_indices.append(sort_within_indices[i])
 
         if(plot):
-            print "BETWEEN"
+            print("BETWEEN")
             for i in range(0,number_to_trim):
-                print names[sort_between_indices[i]]
-            print "WITHIN"
+                print(names[sort_between_indices[i]])
+            print("WITHIN")
             for i in range(0,number_to_trim):
-                print names[sort_within_indices[i]]
+                print(names[sort_within_indices[i]])
 
             plt.figure(1)
             plt.subplot(211)
@@ -1119,20 +1120,20 @@ class BinManager:
 # IO and IMAGE RENDERING
 
     def printBins(self, outFormat, fileName=""):
-        """Wrapper for print handles piping to file or stdout"""
+        """Wrapper for print(handles piping to file or stdout"""
         if("" != fileName):
             try:
                 # redirect stdout to a file
                 stdout = open(fileName, 'w')
                 self.printInner(outFormat, stdout)
             except:
-                print "Error diverting stout to file:", fileName, exc_info()[0]
+                print("Error diverting stout to file:", fileName, exc_info()[0])
                 raise
         else:
             self.printInner(outFormat)
 
     def printInner(self, outFormat, stream=sys_stdout):
-        """Print bin information to STDOUT"""
+        """Print(bin information to STDOUT"""
         # handle the headers first
         separator = "\t"
         if(outFormat == 'contigs'):
@@ -1146,7 +1147,7 @@ class BinManager:
         elif(outFormat == 'full'):
             pass
         else:
-            print "Error: Unrecognised format:", outFormat
+            print("Error: Unrecognised format:", outFormat)
             return
 
         for bid in self.getBids():
@@ -1224,13 +1225,13 @@ class BinManager:
             try:
                 plt.savefig(fileName,dpi=300)
             except:
-                print "Error saving image:", fileName, exc_info()[0]
+                print("Error saving image:", fileName, exc_info()[0])
                 raise
         else:
             try:
                 plt.show()
             except:
-                print "Error showing image:", exc_info()[0]
+                print("Error showing image:", exc_info()[0])
                 raise
 
         plt.close(fig)
@@ -1344,7 +1345,7 @@ class BinManager:
         try:
             plt.show()
         except:
-            print "Error showing image:", exc_info()[0]
+            print("Error showing image:", exc_info()[0])
             raise
 
         plt.close(fig)
@@ -1369,10 +1370,10 @@ class BinManager:
             self.bins[bid].makeBinDist(self.PM.transformedCP, self.PM.averageCoverages, self.PM.kmerNormPC1, self.PM.kmerPCs, self.PM.contigGCs, self.PM.contigLengths)
 
         if(sideBySide):
-            print "Plotting side by side"
+            print("Plotting side by side")
             self.plotSideBySide(self.bins.keys(), tag=FNPrefix, ignoreContigLengths=ignoreContigLengths)
         else:
-            print "Plotting bins"
+            print("Plotting bins")
             for bid in self.getBids():
                 if folder != '':
                     self.bins[bid].plotBin(self.PM.transformedCP, self.PM.contigGCs, self.PM.kmerNormPC1,
@@ -1387,7 +1388,7 @@ class BinManager:
     def plotBinCoverage(self, plotEllipses=False, plotContigLengs=False, printID=False):
         """Make plots of all the bins"""
 
-        print "Plotting first 3 stoits in untransformed coverage space"
+        print("Plotting first 3 stoits in untransformed coverage space")
 
         # plot contigs in coverage space
         fig = plt.figure()
@@ -1452,7 +1453,7 @@ class BinManager:
             plt.show()
             plt.close(fig)
         except:
-            print "Error showing image", exc_info()[0]
+            print("Error showing image", exc_info()[0])
             raise
 
         del fig
@@ -1504,13 +1505,13 @@ class BinManager:
                 fig.set_size_inches(12,6)
                 plt.savefig(fileName,dpi=300)
             except:
-                print "Error saving image:", fileName, exc_info()[0]
+                print("Error saving image:", fileName, exc_info()[0])
                 raise
         elif(show):
             try:
                 plt.show()
             except:
-                print "Error showing image:", exc_info()[0]
+                print("Error showing image:", exc_info()[0])
                 raise
         plt.close(fig)
         del fig
@@ -1554,7 +1555,7 @@ class BinManager:
             plt.show()
             plt.close(fig)
         except:
-            print "Error showing image", exc_info()[0]
+            print("Error showing image", exc_info()[0])
             raise
         del fig
 
@@ -1563,7 +1564,7 @@ class BinManager:
         (bin_centroid_points, _bin_centroid_colors, bin_centroid_gc, _bids) = self.findCoreCentres(processChimeric=showChimeric)
         fig = plt.figure()
         ax = fig.add_subplot(111, projection='3d')
-        print bin_centroid_gc
+        print(bin_centroid_gc)
         sc = ax.scatter(bin_centroid_points[:,0], bin_centroid_points[:,1], bin_centroid_points[:,2], edgecolors='k', c=bin_centroid_gc, cmap=self.PM.colorMapGC, vmin=0.0, vmax=1.0)
         sc.set_edgecolors = sc.set_facecolors = lambda *args:None # disable depth transparency effect
 
@@ -1588,7 +1589,7 @@ class BinManager:
             plt.show()
             plt.close(fig)
         except:
-            print "Error showing image", exc_info()[0]
+            print("Error showing image", exc_info()[0])
             raise
         del fig
 

--- a/groopm/cluster.py
+++ b/groopm/cluster.py
@@ -52,7 +52,7 @@ from sys import stdout, exit
 
 from colorsys import hsv_to_rgb as htr
 import matplotlib.pyplot as plt
-from pylab import show
+
 from numpy import (abs as np_abs,
                    allclose as np_allclose,
                    append as np_append,
@@ -1125,7 +1125,7 @@ class ClusterEngine:
         if(fileName != ""):
             fig.set_size_inches(6,6)
             plt.savefig(fileName,dpi=300)
-        elif(show):
+        else:
             plt.show()
 
         plt.close(fig)
@@ -1186,7 +1186,7 @@ class ClusterEngine:
         if(fileName != ""):
             fig.set_size_inches(6,6)
             plt.savefig(fileName,dpi=300)
-        elif(show):
+        else:
             plt.show()
 
         plt.close(fig)
@@ -1236,7 +1236,7 @@ class ClusterEngine:
                 fig.set_size_inches(18,18)
 
             plt.savefig(fileName,dpi=300)
-        elif(show):
+        else:
             plt.show()
 
         plt.close(fig)

--- a/groopm/cluster.py
+++ b/groopm/cluster.py
@@ -37,6 +37,7 @@
 #    along with this program. If not, see <http://www.gnu.org/licenses/>.     #
 #                                                                             #
 ###############################################################################
+from __future__ import print_function
 
 __author__ = "Michael Imelfort"
 __copyright__ = "Copyright 2012/2013"
@@ -164,16 +165,16 @@ class ClusterEngine:
                                            " If you continue you *MAY* overwrite existing bins!\n" \
                                            " Overwrite? ("+vrs+") : ")
                     if(option.upper() in valid_responses):
-                        print "****************************************************************"
+                        print("****************************************************************")
                         if(option.upper() == "N"):
-                            print "Operation cancelled"
+                            print("Operation cancelled")
                             return False
                         else:
                             break
                     else:
-                        print "Error, unrecognised choice '"+option.upper()+"'"
+                        print("Error, unrecognised choice '"+option.upper()+"'")
                         minimal = True
-            print "Will Overwrite database",self.PM.dbFileName
+            print("Will Overwrite database",self.PM.dbFileName)
         return True
 
 #------------------------------------------------------------------------------
@@ -187,10 +188,10 @@ class ClusterEngine:
 
         # get some data
         self.PM.loadData(self.timer, "length >= "+str(coreCut))
-        print "    %s" % self.timer.getTimeStamp()
+        print("    %s" % self.timer.getTimeStamp())
 
         # transform the data
-        print "    Loading transformed data"
+        print("    Loading transformed data")
         self.PM.transformCP(self.timer)
         # plot the transformed space (if we've been asked to...)
         #if(self.debugPlots >= 3):
@@ -199,15 +200,15 @@ class ClusterEngine:
         # now we can make this guy
         self.TSpan = np_mean([np_norm(self.PM.corners[i] - self.PM.TCentre) for i in range(self.PM.numStoits)])
 
-        print "    %s" % self.timer.getTimeStamp()
+        print("    %s" % self.timer.getTimeStamp())
 
         # cluster and bin!
-        print "Create cores"
+        print("Create cores")
         self.initialiseCores(kmerThreshold, coverageThreshold)
-        print "    %s" % self.timer.getTimeStamp()
+        print("    %s" % self.timer.getTimeStamp())
 
         # condense cores
-        print "Refine cores [begin: %d]" % len(self.BM.bins)
+        print("Refine cores [begin: %d]" % len(self.BM.bins))
         if self.finalPlot:
             prfx = "CORE"
         else:
@@ -215,9 +216,9 @@ class ClusterEngine:
         self.RE.refineBins(self.timer, auto=True, saveBins=False, plotFinal=prfx, gf=gf)
 
         # Now save all the stuff to disk!
-        print "Saving bins"
+        print("Saving bins")
         self.BM.saveBins(nuke=True)
-        print "    %s" % self.timer.getTimeStamp()
+        print("    %s" % self.timer.getTimeStamp())
 
     def initialiseCores(self, kmerThreshold, coverageThreshold):
         """Process contigs and form CORE bins"""
@@ -228,8 +229,8 @@ class ClusterEngine:
         # We can make a heat map and look for hot spots
         self.populateImageMaps()
         sub_counter = 0
-        print "     .... .... .... .... .... .... .... .... .... ...."
-        print "%4d" % sub_counter,
+        print("     .... .... .... .... .... .... .... .... .... ....")
+        print("%4d" % sub_counter,)
         new_line_counter = 0
         num_bins = 0
 
@@ -301,13 +302,13 @@ class ClusterEngine:
                         self.updatePostBin(bin)
 
                         new_line_counter += 1
-                        print "% 4d" % bin.binSize,
+                        print("% 4d" % bin.binSize,)
 
                         # make the printing prettier
                         if(new_line_counter > 9):
                             new_line_counter = 0
                             sub_counter += 10
-                            print "\n%4d" % sub_counter,
+                            print("\n%4d" % sub_counter,)
 
                         if(self.debugPlots >= 1):
                             #***slow plot!
@@ -315,7 +316,7 @@ class ClusterEngine:
 
                     except BinNotFoundException: pass
 
-        print "\n     .... .... .... .... .... .... .... .... .... ...."
+        print("\n     .... .... .... .... .... .... .... .... .... ....")
 
     def findNewClusterCenters(self, kmerThreshold, coverageThreshold):
         """Find a putative cluster"""
@@ -496,32 +497,32 @@ class ClusterEngine:
                 k_dist_matrix = squareform(pdist(k_dat, 'cityblock'))
                 k_radius = np_median(np_sort(k_dist_matrix)[:,eps_neighbours])
             except MemoryError:
-                print "\n"
-                print '*******************************************************************************'
-                print '*********************************    ERROR    *********************************'
-                print '*******************************************************************************'
-                print 'GroopM is attempting to do some maths on a putative bin which contains:'
-                print
-                print '\t\t%d contigs'  % (len(rowIndices))
-                print
-                print 'This has caused your machine to run out of memory.'
-                print 'The most likely cause is that your samples are very different from each other.'
-                print 'You can confirm this by running:'
-                print
-                print '\t\tgroopm explore -m allcontigs %s' % self.PM.dbFileName
-                print
-                print 'If you notice only vertical "spears" of contigs at the corners of the plot then'
-                print 'this means that your samples are very different and you are not getting a good'
-                print 'mapping from all samples to all contigs. You may get more mileage by assembling'
-                print 'and binning your samples separately.'
-                print
-                print 'If you notice "clouds" of contigs then congratulations! You have found a bug.'
-                print 'Please let me know at "%s or via github.com/ecogenomics/GroopM' % __email__
-                print
-                print 'GroopM is aborting... sorry'
-                print
-                print '*******************************************************************************'
-                print "\n"
+                print("\n")
+                print('*******************************************************************************')
+                print('*********************************    ERROR    *********************************')
+                print('*******************************************************************************')
+                print('GroopM is attempting to do some maths on a putative bin which contains:')
+                print()
+                print('\t\t%d contigs'  % (len(rowIndices)))
+                print()
+                print('This has caused your machine to run out of memory.')
+                print('The most likely cause is that your samples are very different from each other.')
+                print('You can confirm this by running:')
+                print()
+                print('\t\tgroopm explore -m allcontigs %s' % self.PM.dbFileName)
+                print()
+                print('If you notice only vertical "spears" of contigs at the corners of the plot then')
+                print('this means that your samples are very different and you are not getting a good')
+                print('mapping from all samples to all contigs. You may get more mileage by assembling')
+                print('and binning your samples separately.')
+                print()
+                print('If you notice "clouds" of contigs then congratulations! You have found a bug.')
+                print('Please let me know at "%s or via github.com/ecogenomics/GroopM' % __email__)
+                print()
+                print('GroopM is aborting... sorry')
+                print()
+                print('*******************************************************************************')
+                print("\n")
                 exit(-1)
 
             # find nearest neighbours to each point in whitened coverage space,
@@ -606,7 +607,7 @@ class ClusterEngine:
                 l_dat = np_delete(l_dat, noise, axis = 0)
                 row_indices = np_delete(row_indices, noise, axis = 0)
                 if self.debugPlots >= 2:
-                    #print "Noise deleting_%d_%d:\n" % (self.cluster_num, iter), n_dat[noise]
+                    #print("Noise deleting_%d_%d:\n" % (self.cluster_num, iter), n_dat[noise])
                     n_dat = np_delete(n_dat, noise, axis = 0)
 
             if len(row_indices) == 0:
@@ -1730,31 +1731,31 @@ class HoughPartitioner:
         try:
             flat_indices = Rs * cols + Cs
         except ValueError:
-            print "\n"
-            print '*******************************************************************************'
-            print '*********************************    ERROR    *********************************'
-            print '*******************************************************************************'
-            print 'GroopM is attempting to do some maths on a putative bin which contains'
-            print 'too many contigs.'
-            print
-            print 'This has resulted in a buffer overflow in the numpy library... oops.'
-            print 'The most likely cause is that your samples are very different from each other.'
-            print 'You can confirm this by running:'
-            print
-            print '\t\tgroopm explore -c 0 -m allcontigs <dbfilename>'
-            print
-            print 'If you notice only vertical "spears" of contigs at the corners of the plot then'
-            print 'this means that your samples are very different and you are not getting a good'
-            print 'mapping from all samples to all contigs. You may get more mileage by assembling'
-            print 'and binning your samples separately.'
-            print
-            print 'If you notice "clouds" of contigs then congratulations! You have found a bug.'
-            print 'Please let me know at "%s or via github.com/ecogenomics/GroopM' % __email__
-            print
-            print 'GroopM is aborting... sorry'
-            print
-            print '*******************************************************************************'
-            print "\n"
+            print("\n")
+            print('*******************************************************************************')
+            print('*********************************    ERROR    *********************************')
+            print('*******************************************************************************')
+            print('GroopM is attempting to do some maths on a putative bin which contains')
+            print('too many contigs.')
+            print()
+            print('This has resulted in a buffer overflow in the numpy library... oops.')
+            print('The most likely cause is that your samples are very different from each other.')
+            print('You can confirm this by running:')
+            print()
+            print('\t\tgroopm explore -c 0 -m allcontigs <dbfilename>')
+            print()
+            print('If you notice only vertical "spears" of contigs at the corners of the plot then')
+            print('this means that your samples are very different and you are not getting a good')
+            print('mapping from all samples to all contigs. You may get more mileage by assembling')
+            print('and binning your samples separately.')
+            print()
+            print('If you notice "clouds" of contigs then congratulations! You have found a bug.')
+            print('Please let me know at "%s or via github.com/ecogenomics/GroopM' % __email__)
+            print()
+            print('GroopM is aborting... sorry')
+            print()
+            print('*******************************************************************************')
+            print("\n")
             exit(-1)
 
         # update the accumulator with integer decrements

--- a/groopm/profileManager.py
+++ b/groopm/profileManager.py
@@ -37,6 +37,7 @@
 #    along with this program. If not, see <http://www.gnu.org/licenses/>.     #
 #                                                                             #
 ###############################################################################
+from __future__ import print_function
 
 __author__ = "Michael Imelfort"
 __copyright__ = "Copyright 2012/2013"
@@ -179,7 +180,7 @@ class ProfileManager:
         if(silent):
             verbose=False
         if verbose:
-            print "Loading data from:", self.dbFileName
+            print("Loading data from:", self.dbFileName)
 
         try:
             self.numStoits = self.getNumStoits()
@@ -188,19 +189,19 @@ class ProfileManager:
                                                                   condition=condition,
                                                                   silent=silent)
             if(verbose):
-                print "    Loaded indices with condition:", condition
+                print("    Loaded indices with condition:", condition)
             self.numContigs = len(self.indices)
 
             if self.numContigs == 0:
-                print "    ERROR: No contigs loaded using condition:", condition
+                print("    ERROR: No contigs loaded using condition:", condition)
                 return
 
             if(not silent):
-                print "    Working with: %d contigs" % self.numContigs
+                print("    Working with: %d contigs" % self.numContigs)
 
             if(loadCovProfiles):
                 if(verbose):
-                    print "    Loading coverage profiles"
+                    print("    Loading coverage profiles")
                 self.covProfiles = self.dataManager.getCoverageProfiles(self.dbFileName, indices=self.indices)
                 self.normCoverages = self.dataManager.getNormalisedCoverageProfiles(self.dbFileName, indices=self.indices)
 
@@ -209,14 +210,14 @@ class ProfileManager:
 
             if loadRawKmers:
                 if(verbose):
-                    print "    Loading RAW kmer sigs"
+                    print("    Loading RAW kmer sigs")
                 self.kmerSigs = self.dataManager.getKmerSigs(self.dbFileName, indices=self.indices)
 
             if(loadKmerPCs):
                 self.kmerPCs = self.dataManager.getKmerPCAs(self.dbFileName, indices=self.indices)
 
                 if(verbose):
-                    print "    Loading PCA kmer sigs (" + str(len(self.kmerPCs[0])) + " dimensional space)"
+                    print("    Loading PCA kmer sigs (" + str(len(self.kmerPCs[0])) + " dimensional space)")
 
                 self.kmerNormPC1 = np_copy(self.kmerPCs[:,0])
                 self.kmerNormPC1 -= np_min(self.kmerNormPC1)
@@ -226,26 +227,26 @@ class ProfileManager:
                 self.kmerVarPC = self.dataManager.getKmerVarPC(self.dbFileName, indices=self.indices)
 
                 if(verbose):
-                    print "    Loading PCA kmer variance (total variance: %.2f" % np_sum(self.kmerVarPC) + ")"
+                    print("    Loading PCA kmer variance (total variance: %.2f" % np_sum(self.kmerVarPC) + ")")
 
             if(loadContigNames):
                 if(verbose):
-                    print "    Loading contig names"
+                    print("    Loading contig names")
                 self.contigNames = self.dataManager.getContigNames(self.dbFileName, indices=self.indices)
 
             if(loadContigLengths):
                 self.contigLengths = self.dataManager.getContigLengths(self.dbFileName, indices=self.indices)
                 if(verbose):
-                    print "    Loading contig lengths (Total: %d BP)" % ( sum(self.contigLengths) )
+                    print("    Loading contig lengths (Total: %d BP)" % ( sum(self.contigLengths) ))
 
             if(loadContigGCs):
                 self.contigGCs = self.dataManager.getContigGCs(self.dbFileName, indices=self.indices)
                 if(verbose):
-                    print "    Loading contig GC ratios (Average GC: %0.3f)" % ( np_mean(self.contigGCs) )
+                    print("    Loading contig GC ratios (Average GC: %0.3f)" % ( np_mean(self.contigGCs) ))
 
             if(makeColors):
                 if(verbose):
-                    print "    Creating color map"
+                    print("    Creating color map")
 
                 # use HSV to RGB to generate colors
                 S = 1       # SAT and VAL remain fixed at 1. Reduce to make
@@ -254,7 +255,7 @@ class ProfileManager:
 
             if(loadBins):
                 if(verbose):
-                    print "    Loading bin assignments"
+                    print("    Loading bin assignments")
 
                 self.binIds = self.dataManager.getBins(self.dbFileName, indices=self.indices)
 
@@ -289,7 +290,7 @@ class ProfileManager:
             self.stoitColNames = self.getStoitColNames()
 
         except:
-            print "Error loading DB:", self.dbFileName, exc_info()[0]
+            print("Error loading DB:", self.dbFileName, exc_info()[0])
             raise
 
     def reduceIndices(self, deadRowIndices):
@@ -497,7 +498,7 @@ class ProfileManager:
     def transformCP(self, timer, silent=False, nolog=False):
         """Do the main transformation on the coverage profile data"""
         if(not silent):
-            print "    Reticulating splines"
+            print("    Reticulating splines")
         self.transformedCP = self.dataManager.getTransformedCoverageProfiles(self.dbFileName, indices=self.indices)
         self.corners = self.dataManager.getTransformedCoverageCorners(self.dbFileName)
         self.TCentre = np_mean(self.corners, axis=0)
@@ -617,7 +618,7 @@ class ProfileManager:
             if self.numStoits == 3:
                 self.transformedCP = self.covProfiles
             else:
-                print "Number of stoits != 3. You need to transform"
+                print("Number of stoits != 3. You need to transform")
                 self.transformCP(timer)
 
         fig = plt.figure()
@@ -633,7 +634,7 @@ class ProfileManager:
             plt.show()
             plt.close(fig)
         except:
-            print "Error showing image", exc_info()[0]
+            print("Error showing image", exc_info()[0])
             raise
         del fig
 
@@ -646,7 +647,7 @@ class ProfileManager:
             if self.numStoits == 3:
                 self.transformedCP = self.covProfiles
             else:
-                print "Number of stoits != 3. You need to transform"
+                print("Number of stoits != 3. You need to transform")
                 self.transformCP(timer)
 
         fig = plt.figure()
@@ -691,7 +692,7 @@ class ProfileManager:
             plt.show()
             plt.close(fig)
         except:
-            print "Error showing image", exc_info()[0]
+            print("Error showing image", exc_info()[0])
             raise
         del fig
 
@@ -801,7 +802,7 @@ class ProfileManager:
             ax = fig.add_subplot(111, projection='3d')
             if len(restrictedBids) == 0:
                 if highlight is None:
-                    print "BF:", np_shape(self.transformedCP)
+                    print("BF:", np_shape(self.transformedCP))
                     if ignoreContigLengths:
                         sc = ax.scatter(self.transformedCP[:,0],
                                    self.transformedCP[:,1],
@@ -895,7 +896,7 @@ class ProfileManager:
                                     marker='.')
                     sc.set_edgecolors = sc.set_facecolors = lambda *args:None # disable depth transparency effect
 
-                    print np_shape(disp_vals), np_shape(hide_vals), np_shape(self.transformedCP)
+                    print(np_shape(disp_vals), np_shape(hide_vals), np_shape(self.transformedCP))
 
                 # render color bar
                 cbar = plt.colorbar(sc, shrink=0.5)
@@ -914,7 +915,7 @@ class ProfileManager:
                         r_cols = np_append(r_cols, self.contigGCs[i])
                         num_added += 1
                 r_trans = np_reshape(r_trans, (num_added,3))
-                print np_shape(r_trans)
+                print(np_shape(r_trans))
                 #r_cols = np_reshape(r_cols, (num_added,3))
                 sc = ax.scatter(r_trans[:,0],
                                 r_trans[:,1],
@@ -958,13 +959,13 @@ class ProfileManager:
                     fig.set_size_inches(primaryWidth,primaryWidth)
                 plt.savefig(fileName,dpi=dpi,format=format)
             except:
-                print "Error saving image",fileName, exc_info()[0]
+                print("Error saving image",fileName, exc_info()[0])
                 raise
         elif(show):
             try:
                 plt.show()
             except:
-                print "Error showing image", exc_info()[0]
+                print("Error showing image", exc_info()[0])
                 raise
         if del_fig:
             plt.close(fig)
@@ -1075,13 +1076,13 @@ class ProfileManager:
                 fig.set_size_inches(primaryWidth,primaryWidth)
                 plt.savefig(fileName,dpi=dpi,format=format)
             except:
-                print "Error saving image",fileName, exc_info()[0]
+                print("Error saving image",fileName, exc_info()[0])
                 raise
         else:
             try:
                 plt.show()
             except:
-                print "Error showing image", exc_info()[0]
+                print("Error showing image", exc_info()[0])
                 raise
 
 ###############################################################################

--- a/groopm/profileManager.py
+++ b/groopm/profileManager.py
@@ -54,8 +54,7 @@ from colorsys import hsv_to_rgb as htr
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.cm import get_cmap
-from mpl_toolkits.mplot3d import axes3d, Axes3D
-from pylab import plot,subplot,axis,stem,show,figure
+
 from numpy import (abs as np_abs,
                    amax as np_amax,
                    amin as np_amin,


### PR DESCRIPTION
- change print statements to print function
- removed pylab imports

`pylab` is intended for interactive use, not use in scripts.  We are trying to discourage it's use and there is a someone squating on `pylab` on pypi (https://pypi.python.org/pypi/pylab) which can confuses users which results in bug reports to the mpl mailing lists.